### PR TITLE
Add React frontend skeleton

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,35 @@
+# CodeWeaver Frontend
+
+This React application provides a simple interface for interacting with the CodeWeaver backend. It was bootstrapped manually with a Vite-like structure and uses Tailwind CSS for styling.
+
+## Development
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Start the development server
+
+```bash
+npm run dev
+```
+
+The app expects the backend to expose the endpoint `/api/generate/`.
+
+## Build
+
+```bash
+npm run build
+```
+
+## Project Structure
+
+- `src/components` – reusable UI components
+- `src/pages` – application pages
+- `src/services` – API helper using Axios
+
+## Notes
+
+Since this environment doesn't include preinstalled node modules, you may need to install them before running the project.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CodeWeaver</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "codeweaver-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,12 @@
+import { Routes, Route } from 'react-router-dom';
+import HomePage from './pages/HomePage';
+import ResultPage from './pages/ResultPage';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="/result" element={<ResultPage />} />
+    </Routes>
+  );
+}

--- a/frontend/src/components/Button.jsx
+++ b/frontend/src/components/Button.jsx
@@ -1,0 +1,15 @@
+export default function Button({ as: Component = 'button', children, className = '', ...props }) {
+  const classes = `px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 ${className}`;
+  if (Component === 'button') {
+    return (
+      <button className={classes} {...props}>
+        {children}
+      </button>
+    );
+  }
+  return (
+    <Component className={classes} {...props}>
+      {children}
+    </Component>
+  );
+}

--- a/frontend/src/components/Input.jsx
+++ b/frontend/src/components/Input.jsx
@@ -1,0 +1,8 @@
+export default function Input({ className = '', ...props }) {
+  return (
+    <input
+      className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring ${className}`}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ProgressSteps.jsx
+++ b/frontend/src/components/ProgressSteps.jsx
@@ -1,0 +1,20 @@
+const steps = ['Prompt Enhancer', 'Scrum Master', 'Dev Agents', 'QA'];
+
+export default function ProgressSteps({ currentStep = 0 }) {
+  return (
+    <ol className="flex space-x-4 mb-4">
+      {steps.map((step, index) => (
+        <li key={step} className="flex items-center">
+          <span
+            className={`h-6 w-6 flex items-center justify-center rounded-full mr-2 ${
+              index <= currentStep ? 'bg-blue-600 text-white' : 'bg-gray-300'
+            }`}
+          >
+            {index + 1}
+          </span>
+          <span className={index <= currentStep ? 'font-semibold' : ''}>{step}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './main.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { generatePrompt } from '../services/api';
+import Button from '../components/Button';
+import Input from '../components/Input';
+import ProgressSteps from '../components/ProgressSteps';
+
+export default function HomePage() {
+  const [prompt, setPrompt] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await generatePrompt(prompt);
+      navigate('/result', { state: { result: data.enhanced_prompt } });
+    } catch (err) {
+      setError('Failed to generate prompt');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4 max-w-2xl">
+      <h1 className="text-2xl font-bold mb-4 text-center">CodeWeaver</h1>
+      <ProgressSteps currentStep={0} />
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <label className="block">
+          <span className="text-gray-700">Enter your prompt</span>
+          <textarea
+            className="mt-1 w-full p-2 border rounded"
+            rows="5"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Type your prompt here..."
+            required
+          />
+        </label>
+        {error && <p className="text-red-600">{error}</p>}
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? 'Processing...' : 'Submit'}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/ResultPage.jsx
+++ b/frontend/src/pages/ResultPage.jsx
@@ -1,0 +1,25 @@
+import { useLocation, Link } from 'react-router-dom';
+import ProgressSteps from '../components/ProgressSteps';
+import Button from '../components/Button';
+
+export default function ResultPage() {
+  const location = useLocation();
+  const result = location.state?.result || '';
+
+  return (
+    <div className="container mx-auto p-4 max-w-2xl">
+      <h1 className="text-2xl font-bold mb-4 text-center">Result</h1>
+      <ProgressSteps currentStep={3} />
+      {result ? (
+        <pre className="whitespace-pre-wrap p-4 bg-gray-100 dark:bg-gray-800 rounded mb-4 border">
+          {result}
+        </pre>
+      ) : (
+        <p className="text-gray-600">No result available.</p>
+      )}
+      <Button as={Link} to="/" className="w-full text-center">
+        Back
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api',
+});
+
+export const generatePrompt = (prompt) =>
+  api.post('/generate/', { prompt });
+
+export default api;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- add a new `frontend/` directory with React source code
- configure Tailwind CSS and Vite-style setup
- implement pages and components for prompt input and result display
- add API helper using Axios

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`
